### PR TITLE
Heartbeat monitor should not fail if task token no longer exists

### DIFF
--- a/app/step-functions-templates/heartbeat_monitor_sfn_template.asl.json
+++ b/app/step-functions-templates/heartbeat_monitor_sfn_template.asl.json
@@ -155,6 +155,29 @@
               "TaskToken": "{% $taskToken %}"
             },
             "Resource": "arn:aws:states:::aws-sdk:sfn:sendTaskHeartbeat",
+            "End": true,
+            "Catch": [
+              {
+                "ErrorEquals": ["Sfn.TaskTimedOutException"],
+                "Next": "Delete job",
+                "Comment": "Token does not exist"
+              }
+            ]
+          },
+          "Delete job": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::dynamodb:deleteItem",
+            "Arguments": {
+              "TableName": "${__task_token_table_name__}",
+              "Key": {
+                "id": {
+                  "S": "{% $jobId %}"
+                },
+                "id_type": {
+                  "S": "${__job_id_type__}"
+                }
+              }
+            },
             "End": true
           },
           "Pass": {


### PR DESCRIPTION
Resolves https://github.com/OrcaBus/service-fastq-decompression-manager/issues/15